### PR TITLE
feat: add industries page and footer links

### DIFF
--- a/src/app/industries/page.tsx
+++ b/src/app/industries/page.tsx
@@ -1,0 +1,89 @@
+import Header from "@/components/header"
+import Footer from "@/components/footer"
+
+const industries = [
+  {
+    id: "healthcare",
+    title: "Healthcare",
+    content:
+      "Clinicians access records, charts, and diagnostic tools with fewer logins and stronger patient privacy. Browser-based controls allow secure telehealth and on-site workflows without extra agents.",
+  },
+  {
+    id: "higher-education",
+    title: "Higher Education",
+    content:
+      "Faculty, students, and staff reach campus systems from anywhere while protecting research and student data. Policies follow users across labs, dorms, and study-abroad connections.",
+  },
+  {
+    id: "financial-services",
+    title: "Financial Services",
+    content:
+      "Advisors and traders interact with portfolios and banking portals in a hardened environment that enforces compliance and prevents data exfiltration. Session recording and DLP keep regulators happy.",
+  },
+  {
+    id: "third-party-contractors",
+    title: "3rd-Party Contractors",
+    content:
+      "Temporary staff and partners get instant, least-privilege access through the browser. No need to ship laptops—permissions, logging, and watermarking travel with the session.",
+  },
+  {
+    id: "byod-workforce",
+    title: "BYOD Workforce",
+    content:
+      "Employees can use personal devices without mingling personal and corporate data. Contextual policies isolate work resources, check device health, and shut off risky actions like copy or screenshot.",
+  },
+]
+
+export default function IndustriesPage() {
+  return (
+    <div className="min-h-screen bg-white">
+      <Header />
+
+      <section className="py-12 sm:py-20 md:py-32">
+        <div className="container mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="text-center max-w-4xl mx-auto">
+            <h1 className="text-4xl sm:text-5xl md:text-6xl font-light text-gray-900 mb-4">
+              Industries
+            </h1>
+            <p className="text-gray-600 mb-8 md:mb-12 max-w-2xl mx-auto leading-relaxed text-sm sm:text-base">
+              Wootzapp Mobile Browser adapts to the needs of modern sectors, protecting data without slowing down work.
+            </p>
+            <div className="flex flex-wrap justify-center gap-4">
+              {industries.map((industry) => (
+                <a
+                  key={industry.id}
+                  href={`#${industry.id}`}
+                  className="px-6 py-2 rounded-full text-sm font-medium bg-gray-100 text-gray-600 hover:bg-gray-200 transition-colors"
+                >
+                  {industry.title}
+                </a>
+              ))}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {industries.map((industry, index) => (
+        <section
+          key={industry.id}
+          id={industry.id}
+          className={`${index % 2 === 0 ? "bg-white" : "bg-gray-50"} py-12 md:py-16`}
+        >
+          <div className="container mx-auto px-4 sm:px-6 lg:px-8">
+            <div className="max-w-3xl mx-auto">
+              <h2 className="text-2xl md:text-3xl font-light text-gray-900 mb-4">
+                {industry.title}
+              </h2>
+              <p className="text-gray-600 leading-relaxed text-sm sm:text-base">
+                {industry.content}
+              </p>
+            </div>
+          </div>
+        </section>
+      ))}
+
+      <Footer />
+    </div>
+  )
+}
+

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -4,7 +4,7 @@ export default function Footer() {
   return (
     <footer className="bg-white border-t border-gray-200 py-8 md:py-12">
       <div className="container mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-8">
+        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-5 gap-8">
           <div className="sm:col-span-2 md:col-span-1">
             <h4 className="font-medium text-gray-900 mb-4">Wootzapp Mobile Browser</h4>
             <p className="text-sm text-gray-600 leading-relaxed mb-4">
@@ -91,6 +91,37 @@ export default function Footer() {
               <li>
                 <Link href="#" className="hover:text-gray-900">
                   Privacy
+                </Link>
+              </li>
+            </ul>
+          </div>
+
+          <div>
+            <h4 className="font-medium text-gray-900 mb-4">Industries</h4>
+            <ul className="space-y-2 text-sm text-gray-600">
+              <li>
+                <Link href="/industries#healthcare" className="hover:text-gray-900">
+                  Healthcare
+                </Link>
+              </li>
+              <li>
+                <Link href="/industries#higher-education" className="hover:text-gray-900">
+                  Higher Education
+                </Link>
+              </li>
+              <li>
+                <Link href="/industries#financial-services" className="hover:text-gray-900">
+                  Financial Services
+                </Link>
+              </li>
+              <li>
+                <Link href="/industries#third-party-contractors" className="hover:text-gray-900">
+                  3rd-Party Contractors
+                </Link>
+              </li>
+              <li>
+                <Link href="/industries#byod-workforce" className="hover:text-gray-900">
+                  BYOD Workforce
                 </Link>
               </li>
             </ul>


### PR DESCRIPTION
## Summary
- create Industries page mirroring the home layout with dedicated sections for key sectors and top anchor links
- add Industries column in the footer linking to each sector

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a275def7883339136293e70899a7e