### PR TITLE
Add legal pages and update footer

### DIFF
--- a/src/app/data-transfer/page.tsx
+++ b/src/app/data-transfer/page.tsx
@@ -1,0 +1,97 @@
+import Header from "@/components/header";
+import Footer from "@/components/footer";
+
+export default function Page() {
+  return (
+    <div className="min-h-screen bg-white">
+      <Header />
+      <section className="py-12 sm:py-20 md:py-32">
+        <div className="container mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="max-w-3xl mx-auto">
+            <h1 className="text-4xl sm:text-5xl md:text-6xl font-light text-gray-900 mb-6">Data Transfer Policy</h1>
+            <div className="space-y-6 text-gray-600 leading-relaxed text-sm sm:text-base">
+              <p className="text-gray-500">Last updated on April 1, 2025</p>
+              <p>
+                This Data Transfer Policy explains how Wootzapp Inc. transfers and protects data
+                between jurisdictions when you use our services.
+              </p>
+              <h2 className="text-xl font-semibold text-gray-900">Record 1: EU Meeting Data to US-Based Processing Infrastructure</h2>
+              <ul className="list-disc pl-6 space-y-2">
+                <li>
+                  <strong>Destination:</strong> United States
+                </li>
+                <li>
+                  <strong>Legal Mechanism:</strong> Standard Contractual Clauses (SCCs)
+                </li>
+                <li>
+                  <strong>Transfer Frequency:</strong> Live during active user sessions
+                </li>
+                <li>
+                  <strong>Objective:</strong> Provide real-time transcription, AI analysis, and
+                  insight generation for European enterprise clients
+                </li>
+                <li>
+                  <strong>Data Types:</strong>
+                  <ul className="list-disc pl-6 space-y-1">
+                    <li>Voice and audio recordings</li>
+                    <li>Generated transcripts and text content</li>
+                    <li>Participant identifiers and meeting metadata</li>
+                  </ul>
+                </li>
+                <li>
+                  <strong>Protective Measures:</strong>
+                  <ul className="list-disc pl-6 space-y-1">
+                    <li>End-to-end encryption (TLS 1.2+)</li>
+                    <li>Encryption at rest using AES-256</li>
+                    <li>Strict access controls and audit logging</li>
+                    <li>Automated deletion after processing</li>
+                  </ul>
+                </li>
+              </ul>
+              <h2 className="text-xl font-semibold text-gray-900">Record 2: EU User Account Data to US-Based Database Infrastructure</h2>
+              <ul className="list-disc pl-6 space-y-2">
+                <li>
+                  <strong>Destination:</strong> United States
+                </li>
+                <li>
+                  <strong>Legal Mechanism:</strong> Standard Contractual Clauses (SCCs)
+                </li>
+                <li>
+                  <strong>Transfer Frequency:</strong> Ongoing for account management
+                </li>
+                <li>
+                  <strong>Objective:</strong> Enable authentication, account management, and
+                  service delivery for EU users
+                </li>
+                <li>
+                  <strong>Data Types:</strong>
+                  <ul className="list-disc pl-6 space-y-1">
+                    <li>Authentication credentials</li>
+                    <li>User profile information</li>
+                    <li>Settings and usage preferences</li>
+                    <li>Session data and login history</li>
+                  </ul>
+                </li>
+                <li>
+                  <strong>Protective Measures:</strong>
+                  <ul className="list-disc pl-6 space-y-1">
+                    <li>AES-256 encryption at rest</li>
+                    <li>Encrypted connections for database access</li>
+                    <li>Multi-factor authentication for administrators</li>
+                    <li>Regular security patches and isolated networks</li>
+                  </ul>
+                </li>
+              </ul>
+              <h2 className="text-xl font-semibold text-gray-900">Contact</h2>
+              <p>
+                For questions about this Data Transfer Policy, contact support@wootzapp.com.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+      <Footer />
+    </div>
+  );
+}
+

--- a/src/app/eula/page.tsx
+++ b/src/app/eula/page.tsx
@@ -1,0 +1,99 @@
+/* eslint-disable react/no-unescaped-entities */
+import Header from "@/components/header";
+import Footer from "@/components/footer";
+
+export default function Page() {
+  return (
+    <div className="min-h-screen bg-white">
+      <Header />
+      <section className="py-12 sm:py-20 md:py-32">
+        <div className="container mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="max-w-3xl mx-auto">
+            <h1 className="text-4xl sm:text-5xl md:text-6xl font-light text-gray-900 mb-6">End User License Agreement</h1>
+            <div className="space-y-6 text-gray-600 leading-relaxed text-sm sm:text-base">
+              <p className="text-gray-500">Last updated: January 2024</p>
+              <h2 className="text-xl font-semibold text-gray-900">1. Acceptance of Terms</h2>
+              <p>
+                By downloading, installing, or using the Wootzapp Mobile Browser ("Software"), you
+                agree to be bound by this End User License Agreement ("Agreement"). If you do not
+                agree to these terms, do not install or use the Software.
+              </p>
+              <h2 className="text-xl font-semibold text-gray-900">2. Description of Service</h2>
+              <p>
+                Wootzapp provides an enterprise mobile browser with zero-trust access controls,
+                data loss prevention, and compliance features designed for organizations.
+              </p>
+              <h2 className="text-xl font-semibold text-gray-900">3. License Grant</h2>
+              <p>
+                Subject to your compliance with this Agreement, Wootzapp grants you a limited,
+                non-exclusive, non-transferable, revocable license to install and use the Software
+                on devices you own or control for your personal or internal business purposes.
+              </p>
+              <ul className="list-disc pl-6 space-y-2">
+                <li>Personal use on your own devices</li>
+                <li>Internal business use within your organization</li>
+                <li>Use in accordance with your subscription plan limits</li>
+              </ul>
+              <h2 className="text-xl font-semibold text-gray-900">4. Use Restrictions</h2>
+              <ul className="list-disc pl-6 space-y-2">
+                <li>Reverse engineer, decompile, or disassemble the Software</li>
+                <li>Remove or modify any proprietary notices or labels</li>
+                <li>Use the Software for any illegal or unauthorized purpose</li>
+                <li>Share your account credentials with unauthorized users</li>
+                <li>Attempt to circumvent usage limitations or security measures</li>
+              </ul>
+              <h2 className="text-xl font-semibold text-gray-900">5. Privacy and Data</h2>
+              <p>
+                Your privacy is important to us. The Software processes screen content and audio
+                data to provide services. All transmissions use end-to-end encryption, and no data
+                is used for model training without your explicit consent.
+              </p>
+              <h2 className="text-xl font-semibold text-gray-900">6. Intellectual Property</h2>
+              <p>
+                The Software and all related intellectual property rights are and remain the
+                exclusive property of Wootzapp Inc. This Agreement does not grant you any rights to
+                Wootzapp trademarks, service marks, or logos.
+              </p>
+              <h2 className="text-xl font-semibold text-gray-900">7. Disclaimers</h2>
+              <p>
+                THE SOFTWARE IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND. WOOTZAPP DISCLAIMS
+                ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO WARRANTIES OF
+                MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NON-INFRINGEMENT.
+              </p>
+              <h2 className="text-xl font-semibold text-gray-900">8. Limitation of Liability</h2>
+              <p>
+                TO THE MAXIMUM EXTENT PERMITTED BY LAW, WOOTZAPP SHALL NOT BE LIABLE FOR ANY
+                INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, OR PUNITIVE DAMAGES, OR ANY LOSS OF
+                PROFITS OR DATA.
+              </p>
+              <h2 className="text-xl font-semibold text-gray-900">9. Termination</h2>
+              <p>
+                This Agreement is effective until terminated. You may terminate it at any time by
+                uninstalling the Software. Wootzapp may terminate this Agreement if you breach any
+                terms. Upon termination, you must cease all use of the Software and destroy all
+                copies.
+              </p>
+              <h2 className="text-xl font-semibold text-gray-900">10. Updates and Modifications</h2>
+              <p>
+                Wootzapp may update the Software and this Agreement from time to time. Continued
+                use of the Software after updates constitutes acceptance of the revised terms.
+              </p>
+              <h2 className="text-xl font-semibold text-gray-900">11. Governing Law</h2>
+              <p>
+                This Agreement is governed by the laws of the State of Delaware, without regard to
+                its conflict of law principles.
+              </p>
+              <h2 className="text-xl font-semibold text-gray-900">12. Contact Information</h2>
+              <p>
+                Wootzapp Inc.<br />Email: legal@wootzapp.com<br />Address: [Company Address]<br />Phone:
+                [Company Phone]
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+      <Footer />
+    </div>
+  );
+}
+

--- a/src/app/privacy-policy/page.tsx
+++ b/src/app/privacy-policy/page.tsx
@@ -1,0 +1,95 @@
+/* eslint-disable react/no-unescaped-entities */
+import Header from "@/components/header";
+import Footer from "@/components/footer";
+
+export default function Page() {
+  return (
+    <div className="min-h-screen bg-white">
+      <Header />
+      <section className="py-12 sm:py-20 md:py-32">
+        <div className="container mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="max-w-3xl mx-auto">
+            <h1 className="text-4xl sm:text-5xl md:text-6xl font-light text-gray-900 mb-6">Privacy Policy</h1>
+            <div className="space-y-6 text-gray-600 leading-relaxed text-sm sm:text-base">
+              <p className="text-gray-500">Last updated on June 10, 2025</p>
+              <p>
+                Your privacy is important to us. This Privacy Policy ("Policy") explains what
+                information Wootzapp Inc. ("we", "us", or "our") collects when you use our website,
+                applications, and services (collectively, the "Services"), how we use that
+                information, and the choices you have.
+              </p>
+              <h2 className="text-xl font-semibold text-gray-900">Scope and Applicability</h2>
+              <p>
+                This Policy applies to information collected when you visit our website or otherwise
+                use the Services. It does not apply where we process information on behalf of our
+                enterprise customers.
+              </p>
+              <h2 className="text-xl font-semibold text-gray-900">Information We Collect</h2>
+              <h3 className="font-semibold text-gray-900">Information You Provide</h3>
+              <ul className="list-disc pl-6 space-y-1">
+                <li>
+                  <strong>Account Information:</strong> name, email, profile picture, and
+                  authentication credentials.
+                </li>
+                <li>
+                  <strong>Payment Information:</strong> billing details and payment method
+                  information processed by our payment providers.
+                </li>
+                <li>
+                  <strong>Recordings and Other Data:</strong> audio recordings, transcripts, or
+                  screenshots submitted through the Services.
+                </li>
+                <li>
+                  <strong>Business Contact Information:</strong> information about your role and
+                  organization when you engage with us on behalf of a company.
+                </li>
+              </ul>
+              <h3 className="font-semibold text-gray-900">Information We Collect Automatically</h3>
+              <ul className="list-disc pl-6 space-y-1">
+                <li>
+                  <strong>Log Data:</strong> IP address, browser type, and how you interact with the
+                  Services.
+                </li>
+                <li>
+                  <strong>Usage Data:</strong> features you use, access times, and pages viewed.
+                </li>
+              </ul>
+              <h2 className="text-xl font-semibold text-gray-900">How We Use Information</h2>
+              <p>
+                We use the information we collect to operate, maintain, and improve the Services,
+                process transactions, provide customer support, and communicate with you about
+                updates and promotional offers.
+              </p>
+              <h2 className="text-xl font-semibold text-gray-900">How We Share Information</h2>
+              <p>
+                We do not sell your personal information. We may share it with service providers
+                that assist in delivering the Services, with your consent, or as required by law.
+              </p>
+              <h2 className="text-xl font-semibold text-gray-900">Your Rights and Choices</h2>
+              <p>
+                You may request access to, correction of, or deletion of your personal information
+                by contacting us. You can also object to or restrict certain processing.
+              </p>
+              <h2 className="text-xl font-semibold text-gray-900">Security</h2>
+              <p>
+                We use administrative, technical, and physical safeguards to protect your
+                information. However, no security measures are perfect or impenetrable.
+              </p>
+              <h2 className="text-xl font-semibold text-gray-900">Changes to this Policy</h2>
+              <p>
+                We may update this Policy from time to time. If we make material changes, we will
+                notify you by posting the new Policy on this page and updating the date above.
+              </p>
+              <h2 className="text-xl font-semibold text-gray-900">Contact</h2>
+              <p>
+                Questions about this Privacy Policy can be sent to privacy@wootzapp.com.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+      <Footer />
+    </div>
+  );
+}
+

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -1,0 +1,79 @@
+/* eslint-disable react/no-unescaped-entities */
+import Header from "@/components/header";
+import Footer from "@/components/footer";
+
+export default function Page() {
+  return (
+    <div className="min-h-screen bg-white">
+      <Header />
+      <section className="py-12 sm:py-20 md:py-32">
+        <div className="container mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="max-w-3xl mx-auto">
+            <h1 className="text-4xl sm:text-5xl md:text-6xl font-light text-gray-900 mb-6">Terms of Service</h1>
+            <div className="space-y-6 text-gray-600 leading-relaxed text-sm sm:text-base">
+              <p className="text-gray-500">Last updated on June 10, 2025</p>
+              <p>
+                These Terms of Service ("Terms") govern your access to and use of the Wootzapp
+                Mobile Browser and related services (collectively, the "Services"). By accessing or
+                using the Services, you agree to be bound by these Terms and our Privacy Policy.
+              </p>
+              <h2 className="text-xl font-semibold text-gray-900">1. Eligibility and Accounts</h2>
+              <p>
+                You must be at least 18 years old and have the authority to enter into these Terms.
+                When you create an account, you must provide accurate information and keep it
+                up-to-date. You are responsible for all activities under your account.
+              </p>
+              <h2 className="text-xl font-semibold text-gray-900">2. Use of the Services</h2>
+              <p>
+                You agree to use the Services only for lawful purposes and in accordance with these
+                Terms. You will not attempt to interfere with or disrupt the integrity or
+                performance of the Services.
+              </p>
+              <h2 className="text-xl font-semibold text-gray-900">3. Subscription and Billing</h2>
+              <p>
+                Some features of the Services may require payment of fees. If you subscribe, your
+                subscription will automatically renew unless you cancel in accordance with your
+                plan's terms. All fees are non-refundable except as required by law.
+              </p>
+              <h2 className="text-xl font-semibold text-gray-900">4. Intellectual Property</h2>
+              <p>
+                The Services, including all related software and content, are owned by Wootzapp or
+                its licensors. We grant you a limited, non-exclusive license to use the Services in
+                accordance with these Terms.
+              </p>
+              <h2 className="text-xl font-semibold text-gray-900">5. Termination</h2>
+              <p>
+                We may suspend or terminate your access to the Services at any time if you violate
+                these Terms. You may cancel your account at any time by contacting support.
+              </p>
+              <h2 className="text-xl font-semibold text-gray-900">6. Disclaimers</h2>
+              <p>
+                THE SERVICES ARE PROVIDED "AS IS" WITHOUT WARRANTIES OF ANY KIND, WHETHER EXPRESS OR
+                IMPLIED. WOOTZAPP DISCLAIMS ALL WARRANTIES INCLUDING ANY IMPLIED WARRANTIES OF
+                MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NON-INFRINGEMENT.
+              </p>
+              <h2 className="text-xl font-semibold text-gray-900">7. Limitation of Liability</h2>
+              <p>
+                TO THE MAXIMUM EXTENT PERMITTED BY LAW, WOOTZAPP SHALL NOT BE LIABLE FOR ANY
+                INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, OR PUNITIVE DAMAGES, OR ANY LOSS OF
+                PROFITS OR DATA.
+              </p>
+              <h2 className="text-xl font-semibold text-gray-900">8. Governing Law and Dispute Resolution</h2>
+              <p>
+                These Terms are governed by the laws of the State of Delaware. Any disputes will be
+                resolved through binding arbitration on an individual basis in accordance with the
+                rules of the American Arbitration Association.
+              </p>
+              <h2 className="text-xl font-semibold text-gray-900">9. Contact</h2>
+              <p>
+                Questions about these Terms can be sent to support@wootzapp.com.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+      <Footer />
+    </div>
+  );
+}
+

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -48,23 +48,23 @@ export default function Footer() {
             <h4 className="font-medium text-gray-900 mb-4">Company</h4>
             <ul className="space-y-2 text-sm text-gray-600">
               <li>
-                <Link href="#" className="hover:text-gray-900">
-                  About
+                <Link href="/eula" className="hover:text-gray-900">
+                  EULA
                 </Link>
               </li>
               <li>
-                <Link href="#" className="hover:text-gray-900">
-                  Blog
+                <Link href="/data-transfer" className="hover:text-gray-900">
+                  Data Transfer
                 </Link>
               </li>
               <li>
-                <Link href="#" className="hover:text-gray-900">
-                  Careers
+                <Link href="/privacy-policy" className="hover:text-gray-900">
+                  Privacy Policy
                 </Link>
               </li>
               <li>
-                <Link href="#" className="hover:text-gray-900">
-                  Contact
+                <Link href="/terms" className="hover:text-gray-900">
+                  Terms
                 </Link>
               </li>
             </ul>


### PR DESCRIPTION
## Summary
- add Wootzapp-branded pages for EULA, Data Transfer Policy, Privacy Policy, and Terms of Service
- link new pages from the footer's Company section

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a297713e8833383833fcf70cc849f