### PR TITLE
feat: add YouTube demo section

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -300,6 +300,24 @@ export default function WootzappMobileBrowserPage() {
         </div>
       </section>
 
+      {/* YouTube Video Section */}
+      <section className="py-12 md:py-16 bg-white">
+        <div className="container mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="max-w-6xl mx-auto">
+            <div className="relative w-full" style={{ paddingBottom: "56.25%" }}>
+              <iframe
+                className="absolute top-0 left-0 w-full h-full rounded-lg"
+                src="https://www.youtube.com/embed/2_74O0V2pBM?modestbranding=1&rel=0"
+                title="Island Mobile Demo"
+                frameBorder="0"
+                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+                allowFullScreen
+              />
+            </div>
+          </div>
+        </div>
+      </section>
+
       {/* Instant, governed access Section */}
       <section id="features" className="py-12 md:py-20 bg-gray-50">
         <div className="container mx-auto px-4 sm:px-6 lg:px-8">


### PR DESCRIPTION
## Summary
- embed Island Mobile demo video under the "This is Wootzapp Mobile Browser" section

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a42e593dc833395f5bb0c9551031f