### PR TITLE
Link CTAs to demo calendar and update nav links

### DIFF
--- a/src/app/future-of-enterprise-browsers/page.tsx
+++ b/src/app/future-of-enterprise-browsers/page.tsx
@@ -376,7 +376,18 @@ export default function Page() {
             their security posture and enable the future of work.
           </p>
           <div className="flex flex-col sm:flex-row gap-4 justify-center">
-            <Button className="bg-black hover:bg-gray-800 text-white px-8 py-3">Schedule Demo</Button>
+            <Button
+              asChild
+              className="bg-black hover:bg-gray-800 text-white px-8 py-3"
+            >
+              <a
+                href="https://calendar.app.google/3QyXM9d359yN6aCu8"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Schedule Demo
+              </a>
+            </Button>
             <Button variant="outline" className="px-8 py-3 bg-transparent">
               Download Research Report
             </Button>

--- a/src/app/industries/page.tsx
+++ b/src/app/industries/page.tsx
@@ -1138,7 +1138,18 @@ export default function IndustriesPage() {
             Discover how Wootzapp Enterprise Browser can address your industry&apos;s specific security and compliance challenges.
           </p>
           <div className="flex flex-col sm:flex-row gap-4 justify-center">
-            <Button className="bg-black hover:bg-gray-800 text-white px-6 py-3">Schedule Demo</Button>
+            <Button
+              asChild
+              className="bg-black hover:bg-gray-800 text-white px-6 py-3"
+            >
+              <a
+                href="https://calendar.app.google/3QyXM9d359yN6aCu8"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Schedule Demo
+              </a>
+            </Button>
             <Button
               variant="outline"
               className="border-gray-300 text-gray-700 hover:bg-gray-50 px-6 py-3 bg-transparent"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -259,8 +259,17 @@ export default function WootzappMobileBrowserPage() {
             </p>
 
             <div className="flex flex-col sm:flex-row gap-4 justify-center items-center">
-              <Button className="bg-black hover:bg-gray-800 text-white px-6 md:px-8 py-3 w-full sm:w-auto">
-                See it on my phone →
+              <Button
+                asChild
+                className="bg-black hover:bg-gray-800 text-white px-6 md:px-8 py-3 w-full sm:w-auto"
+              >
+                <a
+                  href="https://calendar.app.google/3QyXM9d359yN6aCu8"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  See it on my phone →
+                </a>
               </Button>
               <Button
                 variant="outline"
@@ -452,8 +461,17 @@ export default function WootzappMobileBrowserPage() {
             </p>
 
             <div className="flex flex-col sm:flex-row gap-4 justify-center">
-              <Button className="bg-black hover:bg-gray-800 text-white px-6 md:px-8 py-3 w-full sm:w-auto">
-                Start Free Trial
+              <Button
+                asChild
+                className="bg-black hover:bg-gray-800 text-white px-6 md:px-8 py-3 w-full sm:w-auto"
+              >
+                <a
+                  href="https://calendar.app.google/3QyXM9d359yN6aCu8"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Start Free Trial
+                </a>
               </Button>
               <Button
                 variant="outline"

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -11,14 +11,14 @@ export default function Header() {
               Wootzapp Mobile Browser
             </Link>
             <nav className="hidden md:flex items-center space-x-8">
-              <Link href="#" className="text-gray-600 hover:text-gray-900 text-sm">
-                Solutions
+              <Link href="/industries" className="text-gray-600 hover:text-gray-900 text-sm">
+                Industries
               </Link>
-              <Link href="#" className="text-gray-600 hover:text-gray-900 text-sm">
-                Security
-              </Link>
-              <Link href="#" className="text-gray-600 hover:text-gray-900 text-sm">
-                Company
+              <Link
+                href="/future-of-enterprise-browsers"
+                className="text-gray-600 hover:text-gray-900 text-sm"
+              >
+                Enterprise Browser Research
               </Link>
             </nav>
           </div>
@@ -27,7 +27,18 @@ export default function Header() {
             <Link href="#" className="text-gray-600 hover:text-gray-900 text-sm hidden sm:block">
               Sign In
             </Link>
-            <Button className="bg-black hover:bg-gray-800 text-white px-3 md:px-4 py-2 text-sm">Get Started</Button>
+            <Button
+              asChild
+              className="bg-black hover:bg-gray-800 text-white px-3 md:px-4 py-2 text-sm"
+            >
+              <a
+                href="https://calendar.app.google/3QyXM9d359yN6aCu8"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Get Started
+              </a>
+            </Button>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Link header "Get Started" button to demo calendar and add navigation to Industries and Enterprise Browser Research pages
- Connect hero and footer CTA buttons to the calendar link
- Wire up "Schedule Demo" buttons on Industries and Future of Enterprise Browsers pages

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a55d849ec8333bef7bce6e65f47f5