### PR TITLE
fix: mark header as client component

### DIFF
--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { useState } from "react";
 import Link from "next/link";
 import { Menu, X } from "lucide-react";


### PR DESCRIPTION
## Summary
- mark `header.tsx` as a client component so `useState` works

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689ec84ae46c83339cdc7a01b1720e72